### PR TITLE
[bitnami/bncert]chore(workflows): Avoid running workflows in forked repositories

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
             bncert-*.run
   release:
     needs: ['build']
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.repository == 'bitnami/bncert' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-20.04
     name: Release
     env:
@@ -74,7 +74,6 @@ jobs:
           fi
   upload:
     needs: ['build', 'release']
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-20.04
     name: Upload
     env:


### PR DESCRIPTION
### Description of the change

Check repository to avoid running scheduled or CD workflows in forked repositories.

### Benefits

Skip unnecessary executions and failures in forks.

### Possible drawbacks

None

### Checklist

- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
