### PR TITLE
Use ubuntu-latest runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 permissions: {}
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Build
     env:
       INSTALLBUILDER: installbuilder
@@ -39,7 +39,7 @@ jobs:
   release:
     needs: ['build']
     if: github.repository == 'bitnami/bncert' && startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Release
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -74,7 +74,7 @@ jobs:
           fi
   upload:
     needs: ['build', 'release']
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Upload
     env:
       S3_URL: ${{ secrets.S3_URL }}


### PR DESCRIPTION
According to [this blogpost](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/), `ubuntu-20.04` will be deprecated. We should upgrade them to `ubuntu-latest`.

No issues are expected.